### PR TITLE
Default namespace to namespace from kubeconfig

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,9 @@ func main() {
 func runFunc(configFlags *genericclioptions.ConfigFlags) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, posArgs []string) error {
 		namespace := ptr.Deref(configFlags.Namespace, "")
+		if namespace == "" {
+			namespace, _, _ = configFlags.ToRawKubeConfigLoader().Namespace()
+		}
 		return resource.NewBuilder(configFlags).
 			Unstructured().
 			NamespaceParam(namespace).DefaultNamespace().


### PR DESCRIPTION
Before this patch, trying to retrieve a namespaced resource without the `-n` flag fails with the following error, even when a namespace is configured in the kubeconfig:
```
Error: namespace may not be empty when retrieving a resource by name
```